### PR TITLE
upgrade golang version for fix CVE-2024-24790

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
 
     strategy:
       matrix:
-        go-version: [1.18.1]
+        go-version: [1.22.5]
 
     steps:
     - uses: actions/checkout@v2

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/kvz/json2hcl
 
-go 1.17
+go 1.22.5
 
 require github.com/hashicorp/hcl v1.0.0


### PR DESCRIPTION
update golang version in order to fix this CVE

```
go1.22.5 (released 2024-07-02) includes security fixes to the net/http package, as well as bug fixes to the compiler, cgo, the go command, the linker, the runtime, and the crypto/tls, go/types, net, net/http, and os/exec packages. See the [Go 1.22.5 milestone](https://github.com/golang/go/issues?q=milestone%3AGo1.22.5+label%3ACherryPickApproved) on our issue tracker for details.
```

Could you please merge and create a new version? 🙏 

cc @kvz 