### PR TITLE
.goreleaser.yml: Set `version: 2` and `release --snapshot`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         go-version: ${{ matrix.go-version }}
     - uses: goreleaser/goreleaser-action@v6
       with:
-        args: release --snapshot
+        args: ${{ github.ref_type == 'tag' && 'release' || 'release --snapshot' }}
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - uses: actions/upload-artifact@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,9 +22,9 @@ jobs:
     - uses: actions/setup-go@v5
       with:
         go-version: ${{ matrix.go-version }}
-    - uses: goreleaser/goreleaser-action@v2
+    - uses: goreleaser/goreleaser-action@v6
       with:
-        args: release
+        args: release --snapshot
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - uses: actions/upload-artifact@v4

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,3 +1,5 @@
+version: 2
+
 builds:
 -
   goos:
@@ -11,7 +13,7 @@ builds:
 # .goreleaser.yaml
 release:
   # Repo in which the release will be created.
-  # Default is extracted from the origin remote URL or empty if its private hosted.
+  # Default is extracted from the origin remote URL or empty if it is privately hosted.
   github:
     owner: kvz
     name: json2hcl


### PR DESCRIPTION
Fixes: #31
* #31

> ⨯ release failed after 0s                  error=git doesn't contain any tags. Either add a tag or use --snapshot

* https://goreleaser.com/errors/version/?h=.goreleaser.yml#unsupported-configuration-version
* https://goreleaser.com/blog/goreleaser-v2
* https://goreleaser.com/customization/release
* https://goreleaser.com/customization/snapshots